### PR TITLE
Remove duplication in History and Alarms

### DIFF
--- a/lib/obix.rb
+++ b/lib/obix.rb
@@ -9,6 +9,7 @@ module OBIX
   autoload :Watch, "obix/watch"
   autoload :Alarms, "obix/alarms"
   autoload :History, "obix/history"
+  autoload :RecordContainer, "obix/record_container"
   autoload :Tag, "obix/tag"
   autoload :Builder, "obix/builder"
   autoload :Configuration, "obix/configuration"

--- a/lib/obix/alarms.rb
+++ b/lib/obix/alarms.rb
@@ -1,48 +1,6 @@
 module OBIX
 
-  class Alarms
-
-    # Initialize an alarm service.
-    #
-    # source - A Hash of options (see OBIX#parse for details).
-    def initialize source
-      @alarms = OBIX.parse source
-    end
-
-    # The number of alarms.
-    # 
-    # Returns an Integer.
-    def count
-      @alarms.objects.find { |o| o.name == "count" }.val
-    end
-
-    # Query alarms.
-    #
-    # options - A Hash of options:
-    #           :start - A DateTime instance describing the earliest time to query history for.
-    #           :end   - A DateTime instance describing the latest time to query history for.
-    def query options
-      from = options.fetch :start
-      to   = options.fetch :end
-
-      query = @alarms.objects.find { |o| o.name == "query" }
-
-      filter = OBIX::Builder.new do
-        obj do
-          abstime name: "start", val: from.iso8601
-          abstime name: "end", val: to.iso8601
-        end
-      end.object
-
-      alarms = query.invoke filter
-
-      alarms.objects.find { |o| o.name == "data" }
-    end
-
-    def to_s
-      @alarms.to_s
-    end
-
+  class Alarms < RecordContainer
   end
 
 end

--- a/lib/obix/history.rb
+++ b/lib/obix/history.rb
@@ -1,63 +1,22 @@
 module OBIX
 
-  class History
-
-    # Initialize a history.
-    #
-    # source - A Hash of options (see OBIX#parse for details).
-    def initialize source
-      @history = OBIX.parse source
-    end
-
-    # The number of history records contained by the history.
-    # 
-    # Returns an Integer.
-    def count
-      @history.objects.find { |o| o.name == "count" }.val
-    end
+  class History < RecordContainer
 
     # The timestamp of the oldest record contained by the history.
     #
     # Returns a DateTime instance.
     def start
-      @history.objects.find { |o| o.name == "start" }.val
+      @records.objects.find { |o| o.name == "start" }.val
     end
 
     # The timestamp of the newest record contained by the history.
     def end
-      @history.objects.find { |o| o.name == "end" }.val
+      @records.objects.find { |o| o.name == "end" }.val
     end
 
     # The timezone of the history data.
     def timezone
-      @history.objects.find { |o| o.name == "tz" }.val
-    end
-
-    # Query the history records contained by the history.
-    #
-    # options - A Hash of options:
-    #           :start - A DateTime instance describing the earliest time to query history for.
-    #           :end   - A DateTime instance describing the latest time to query history for.
-    def query options
-      from = options.fetch :start
-      to   = options.fetch :end
-
-      query = @history.objects.find { |o| o.name == "query" }
-
-      filter = OBIX::Builder.new do
-        obj do
-          abstime name: "start", val: from.iso8601
-          abstime name: "end", val: to.iso8601
-        end
-      end.object
-
-      history = query.invoke filter
-
-      history.objects.find { |o| o.name == "data" }
-    end
-
-    def to_s
-      @history.to_s
+      @records.objects.find { |o| o.name == "tz" }.val
     end
 
   end

--- a/lib/obix/record_container.rb
+++ b/lib/obix/record_container.rb
@@ -1,0 +1,45 @@
+module OBIX
+
+  class RecordContainer
+    
+    # Initialize a RecordContainer based on OBIX source
+    #
+    # source - A Hash of options (see OBIX#parse for details).
+    def initialize source
+      @records = OBIX.parse source
+    end
+    
+    # The number of records.
+    # 
+    # Returns an Integer.
+    def count
+      @records.objects.find { |o| o.name == "count" }.val
+    end
+    
+    # Query the records
+    #
+    # options - A Hash of options:
+    #           :start - A DateTime instance describing the earliest time to query for.
+    #           :end   - A DateTime instance describing the latest time to query for.
+    def query options
+      from = options.fetch :start
+      to   = options.fetch :end
+
+      query = @records.objects.find { |o| o.name == "query" }
+
+      filter = OBIX::Builder.new do
+        obj do
+          abstime name: "start", val: from.iso8601
+          abstime name: "end", val: to.iso8601
+        end
+      end.object
+
+      filter_result = query.invoke filter
+      filter_result.objects.find { |o| o.name == "data" }
+    end
+
+    def to_s
+      @records.to_s
+    end
+  end
+end


### PR DESCRIPTION
Duplicate code in History and Alarms was factored out
into a new class named RecordContainer. Now, Alarms is empty
but kept for semantic reasons for the time being.
